### PR TITLE
allow dataflow to work with shared vpc networks.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@
 # Make will use bash instead of sh
 SHELL := /usr/bin/env bash
 
-DOCKER_TAG_VERSION_DEVELOPER_TOOLS := 0
+DOCKER_TAG_VERSION_DEVELOPER_TOOLS := 0.11.6
 DOCKER_IMAGE_DEVELOPER_TOOLS := cft/developer-tools
 REGISTRY_URL := gcr.io/cloud-foundation-cicd
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Then perform the following commands on the root folder:
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
+| ip\_configuration | The configuration for VM IPs. Options are 'WORKER_IP_PUBLIC' or 'WORKER_IP_PRIVATE'. | string | `"null"` | no |
 | machine\_type | The machine type to use for the job. | string | `""` | no |
 | max\_workers | The number of workers permitted to work on the job. More workers may improve processing speed at additional cost. | number | `"1"` | no |
 | name | The name of the dataflow job | string | n/a | yes |

--- a/build/int.cloudbuild.yaml
+++ b/build/int.cloudbuild.yaml
@@ -38,4 +38,4 @@ tags:
   - 'integration'
 substitutions:
   _DOCKER_IMAGE_DEVELOPER_TOOLS: 'cft/developer-tools'
-  _DOCKER_TAG_VERSION_DEVELOPER_TOOLS: '0'
+  _DOCKER_TAG_VERSION_DEVELOPER_TOOLS: '0.11.6'

--- a/build/lint.cloudbuild.yaml
+++ b/build/lint.cloudbuild.yaml
@@ -21,4 +21,4 @@ tags:
   - 'lint'
 substitutions:
   _DOCKER_IMAGE_DEVELOPER_TOOLS: 'cft/developer-tools'
-  _DOCKER_TAG_VERSION_DEVELOPER_TOOLS: '0'
+  _DOCKER_TAG_VERSION_DEVELOPER_TOOLS: '0.11.6'

--- a/examples/dlp_api_example/main.tf
+++ b/examples/dlp_api_example/main.tf
@@ -84,16 +84,16 @@ resource "google_kms_key_ring" "create_kms_ring" {
 }
 
 resource "google_kms_crypto_key" "create_kms_key" {
-  count    = var.create_key_ring ? 1 : 0
-  name     = var.kms_key_name
-  key_ring = google_kms_key_ring.create_kms_ring[0].self_link
+  count      = var.create_key_ring ? 1 : 0
+  name       = var.kms_key_name
+  key_ring   = google_kms_key_ring.create_kms_ring[0].self_link
   depends_on = [google_kms_key_ring.create_kms_ring]
 }
 
 resource "null_resource" "create_kms_wrapped_key" {
-  count = var.create_key_ring ? 1 : 0
+  count      = var.create_key_ring ? 1 : 0
   depends_on = [google_kms_crypto_key.create_kms_key]
-  
+
   provisioner "local-exec" {
     command = <<EOF
   rm original_key.txt

--- a/main.tf
+++ b/main.tf
@@ -25,13 +25,9 @@ resource "google_dataflow_job" "dataflow_job" {
   temp_gcs_location     = "gs://${var.temp_gcs_location}/tmp_dir"
   parameters            = var.parameters
   service_account_email = var.service_account_email
-  network               = replace(var.network_self_link, "/(.*)/networks/(.*)/", "$2")
-  subnetwork = replace(
-    var.subnetwork_self_link,
-    "/(.*)/regions/(.*)/",
-    "regions/$2",
-  )
-  machine_type     = var.machine_type
-  ip_configuration = var.ip_configuration
+  network               = var.network_self_link
+  subnetwork            = var.subnetwork_self_link
+  machine_type          = var.machine_type
+  ip_configuration      = var.ip_configuration
 }
 

--- a/test/setup/versions.tf
+++ b/test/setup/versions.tf
@@ -15,5 +15,5 @@
  */
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = "~> 0.12.26"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -89,7 +89,7 @@ variable "machine_type" {
 
 variable "ip_configuration" {
   type        = string
-  description = "The configuration for VM IPs. Options are 'WORKER_IP_PUBLIC' or 'WORKER_IP_PRIVATE'." 
+  description = "The configuration for VM IPs. Options are 'WORKER_IP_PUBLIC' or 'WORKER_IP_PRIVATE'."
   default     = null
 }
 

--- a/versions.tf
+++ b/versions.tf
@@ -15,7 +15,7 @@
  */
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = "~> 0.12.26"
   required_providers {
     google = "~> 2.18"
   }


### PR DESCRIPTION
Using the full self_link URL for the subnetwork, enabling this module to work with a shared vpc setup. 
[ref docs](https://cloud.google.com/dataflow/docs/guides/specifying-networks)

