### PR TITLE
Additional parameters: transform_name_mapping, labels and additional_experiments

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,9 @@ Then perform the following commands on the root folder:
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
+| additional\_experiments | List of experiments that should be used by the job | list(string) | `<list>` | no |
 | ip\_configuration | The configuration for VM IPs. Options are 'WORKER_IP_PUBLIC' or 'WORKER_IP_PRIVATE'. | string | `"null"` | no |
+| labels | User labels to be specified for the job. Keys and values should follow the restrictions specified in the labeling restrictions page. | map(string) | `<map>` | no |
 | machine\_type | The machine type to use for the job. | string | `""` | no |
 | max\_workers | The number of workers permitted to work on the job. More workers may improve processing speed at additional cost. | number | `"1"` | no |
 | name | The name of the dataflow job | string | n/a | yes |
@@ -66,6 +68,7 @@ Then perform the following commands on the root folder:
 | subnetwork\_self\_link | The subnetwork self link to which VMs will be assigned. | string | `""` | no |
 | temp\_gcs\_location | A writeable location on GCS for the Dataflow job to dump its temporary data. | string | n/a | yes |
 | template\_gcs\_path | The GCS path to the Dataflow job template. | string | n/a | yes |
+| transform\_name\_mapping | Only applicable when updating a pipeline. Map of transform name prefixes of the job to be replaced with the corresponding name prefixes of the new job. This field is not used outside of update. | map(string) | `<map>` | no |
 | zone | The zone in which the created job should run. | string | `"us-central1-a"` | no |
 
 ## Outputs

--- a/examples/dlp_api_example/main.tf
+++ b/examples/dlp_api_example/main.tf
@@ -15,7 +15,7 @@
  */
 
 provider "google" {
-  version = "~> 2.18.0"
+  version = "~> 3.49.0"
   region  = var.region
 }
 

--- a/examples/simple_example/main.tf
+++ b/examples/simple_example/main.tf
@@ -15,7 +15,7 @@
  */
 
 provider "google" {
-  version = "~> 2.18.0"
+  version = "~> 3.49.0"
   region  = var.region
 }
 

--- a/main.tf
+++ b/main.tf
@@ -15,19 +15,22 @@
  */
 
 resource "google_dataflow_job" "dataflow_job" {
-  project               = var.project_id
-  region                = var.region
-  zone                  = var.zone
-  name                  = var.name
-  on_delete             = var.on_delete
-  max_workers           = var.max_workers
-  template_gcs_path     = var.template_gcs_path
-  temp_gcs_location     = "gs://${var.temp_gcs_location}/tmp_dir"
-  parameters            = var.parameters
-  service_account_email = var.service_account_email
-  network               = var.network_self_link
-  subnetwork            = var.subnetwork_self_link
-  machine_type          = var.machine_type
-  ip_configuration      = var.ip_configuration
+  project                = var.project_id
+  region                 = var.region
+  zone                   = var.zone
+  name                   = var.name
+  on_delete              = var.on_delete
+  max_workers            = var.max_workers
+  template_gcs_path      = var.template_gcs_path
+  temp_gcs_location      = "gs://${var.temp_gcs_location}/tmp_dir"
+  parameters             = var.parameters
+  service_account_email  = var.service_account_email
+  network                = var.network_self_link
+  subnetwork             = var.subnetwork_self_link
+  machine_type           = var.machine_type
+  ip_configuration       = var.ip_configuration
+  labels                 = var.labels
+  transform_name_mapping = var.transform_name_mapping
+  additional_experiments = var.additional_experiments
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -93,3 +93,19 @@ variable "ip_configuration" {
   default     = null
 }
 
+variable "labels" {
+  type        = map(string)
+  default     = {}
+  description = "User labels to be specified for the job. Keys and values should follow the restrictions specified in the labeling restrictions page."
+}
+variable "transform_name_mapping" {
+  type        = map(string)
+  default     = {}
+  description = "Only applicable when updating a pipeline. Map of transform name prefixes of the job to be replaced with the corresponding name prefixes of the new job. This field is not used outside of update. "
+}
+variable "additional_experiments" {
+  type        = list(string)
+  default     = []
+  description = "List of experiments that should be used by the job"
+}
+


### PR DESCRIPTION
Adding support for 3 parameters that where missing:
- transform_name_mapping
- labels
- additional_experiments

