### PR TITLE
feat: Add CMEK support

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,6 @@ In order to launch a Dataflow Job, the Dataflow API must be enabled:
 
 - Dataflow API - `dataflow.googleapis.com`
 - Compute Engine API: `compute.googleapis.com`
-- Compute Engine API: `compute.googleapis.com`
 
 **Note:** If you want to use a Customer Managed Encryption Key, the Cloud Key Management Service (KMS) API must be enabled:
 

--- a/README.md
+++ b/README.md
@@ -99,29 +99,37 @@ The [project factory](https://github.com/terraform-google-modules/terraform-goog
 - [terraform-provider-google](https://github.com/terraform-providers/terraform-provider-google) plugin v2.18.0
 
 ### Configure a Service Account to execute the module
+
 In order to execute this module you must have a Service Account with the
 following project roles:
+
 - roles/dataflow.admin
 - roles/iam.serviceAccountUser
 - roles/storage.admin
 
-If you want to use the kms_key_name parameter, you need to follow [this guide](https://cloud.google.com/dataflow/docs/guides/customer-managed-encryption-keys), to add the following role in the kms keys:
-- roles/cloudkms.cryptoKeyEncrypterDecrypter
-
 ### Configure a Controller Service Account to create the job
+
 If you want to use the service_account_email input to specify a service account that will identify the VMs in which the jobs are running, the service account will need the following project roles:
+
 - roles/dataflow.worker
 - roles/storage.objectAdmin
 
+### Configure a Customer Managed Encryption Key
+
+If you want to use [Customer Managed Encryption Keys](https://cloud.google.com/kms/docs/cmek) in the [Dataflow Job](https://cloud.google.com/dataflow/docs/guides/customer-managed-encryption-keys) use the variable `kms_key_name` to provide a valid key.
+Follow the instructions in [Granting Encrypter/Decrypter permissions](https://cloud.google.com/dataflow/docs/guides/customer-managed-encryption-keys#granting_encrypterdecrypter_permissions) to configure the necessary roles for the Dataflow service accounts.
+
 ### Enable APIs
+
 In order to launch a Dataflow Job, the Dataflow API must be enabled:
 
 - Dataflow API - `dataflow.googleapis.com`
 - Compute Engine API: `compute.googleapis.com`
 - Compute Engine API: `compute.googleapis.com`
 
-If you want to use the kms_key_name parameter:
-- Cloud Key Management Service: `cloudkms.googleapis.com`
+**Note:** If you want to use a Customer Managed Encryption Key, the Cloud Key Management Service (KMS) API must be enabled:
+
+- Cloud Key Management Service (KMS) API: `cloudkms.googleapis.com`
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Then perform the following commands on the root folder:
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | ip\_configuration | The configuration for VM IPs. Options are 'WORKER\_IP\_PUBLIC' or 'WORKER\_IP\_PRIVATE'. | `string` | `null` | no |
+| kms\_key\_name | The name for the Cloud KMS key for the job. Key format is: projects/PROJECT\_ID/locations/LOCATION/keyRings/KEY\_RING/cryptoKeys/KEY | `string` | `null` | no |
 | machine\_type | The machine type to use for the job. | `string` | `""` | no |
 | max\_workers | The number of workers permitted to work on the job. More workers may improve processing speed at additional cost. | `number` | `1` | no |
 | name | The name of the dataflow job | `string` | n/a | yes |
@@ -104,6 +105,9 @@ following project roles:
 - roles/iam.serviceAccountUser
 - roles/storage.admin
 
+If you want to use the Key Management Service:
+- roles/cloudkms.cryptoKeyEncrypterDecrypter
+
 ### Configure a Controller Service Account to create the job
 If you want to use the service_account_email input to specify a service account that will identify the VMs in which the jobs are running, the service account will need the following project roles:
 - roles/dataflow.worker
@@ -114,6 +118,10 @@ In order to launch a Dataflow Job, the Dataflow API must be enabled:
 
 - Dataflow API - `dataflow.googleapis.com`
 - Compute Engine API: `compute.googleapis.com`
+- Compute Engine API: `compute.googleapis.com`
+
+If you want to use the Key Management Service:
+- Cloud Key Management Service: cloudkms.googleapis.com
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ following project roles:
 - roles/iam.serviceAccountUser
 - roles/storage.admin
 
-If you want to use the Key Management Service:
+If you want to use the kms_key_name parameter, you need to follow [this guide](https://cloud.google.com/dataflow/docs/guides/customer-managed-encryption-keys), to add the following role in the kms keys:
 - roles/cloudkms.cryptoKeyEncrypterDecrypter
 
 ### Configure a Controller Service Account to create the job

--- a/README.md
+++ b/README.md
@@ -120,8 +120,8 @@ In order to launch a Dataflow Job, the Dataflow API must be enabled:
 - Compute Engine API: `compute.googleapis.com`
 - Compute Engine API: `compute.googleapis.com`
 
-If you want to use the Key Management Service:
-- Cloud Key Management Service: cloudkms.googleapis.com
+If you want to use the kms_key_name parameter:
+- Cloud Key Management Service: `cloudkms.googleapis.com`
 
 ## Install
 

--- a/main.tf
+++ b/main.tf
@@ -29,5 +29,6 @@ resource "google_dataflow_job" "dataflow_job" {
   subnetwork            = var.subnetwork_self_link
   machine_type          = var.machine_type
   ip_configuration      = var.ip_configuration
+  kms_key_name          = var.kms_key_name
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -93,3 +93,8 @@ variable "ip_configuration" {
   default     = null
 }
 
+variable "kms_key_name" {
+  type        = string
+  description = "The name for the Cloud KMS key for the job. Key format is: projects/PROJECT_ID/locations/LOCATION/keyRings/KEY_RING/cryptoKeys/KEY"
+  default     = null
+}


### PR DESCRIPTION
Fixes #23

Note: instead of using an empty string, `""` we are using `null`  as the default value as is used in: 

https://github.com/terraform-google-modules/terraform-google-pubsub/blob/30bab0c37593a086f19c7f1cf54bfc5cbe0e083c/variables.tf#L63-L67

```hcl
variable "topic_kms_key_name" {
  type        = string
  description = "The resource name of the Cloud KMS CryptoKey to be used to protect access to messages published on this topic."
  default     = null
}
```