### PR TITLE
chore: add connections metadata with bigquery, pubsub and GCS simple bucket

### DIFF
--- a/modules/flex/metadata.display.yaml
+++ b/modules/flex/metadata.display.yaml
@@ -37,6 +37,11 @@ spec:
         container_spec_gcs_path:
           name: container_spec_gcs_path
           title: Container Spec Gcs Path
+          enumValueLabels:
+            - label: PUBSUB_TO_BIGQUERY_FLEX
+              value: gs://adc-dataflow-templates/images/latest/flex/PubSub_to_BigQuery_Flex
+            - label: PUBSUB_TO_GCS_TEXT_FLEX
+              value: gs://adc-dataflow-templates/images/latest/flex/Cloud_PubSub_to_GCS_Text_Flex
         enable_streaming_engine:
           name: enable_streaming_engine
           title: Enable Streaming Engine

--- a/modules/flex/metadata.yaml
+++ b/modules/flex/metadata.yaml
@@ -126,6 +126,22 @@ spec:
         description: Key/Value pairs to be passed to the Dataflow job (as used in the template).
         varType: map(string)
         defaultValue: {}
+        connections:
+          - source:
+              source: github.com/terraform-google-modules/terraform-google-bigquery
+              version: ">= 10.0.1"
+            spec:
+              outputExpr: "{\"OutputTableSpec\": table_ids[0]}"
+          - source:
+              source: github.com/terraform-google-modules/terraform-google-pubsub
+              version: ">= 8.0.1"
+            spec:
+              outputExpr: "{\"InputTopic\": id}"
+          - source:
+              source: github.com/terraform-google-modules/terraform-google-cloud-storage//modules/simple_bucket
+              version: ">= 9.1.0"
+            spec:
+              outputExpr: "{\"OutputDirectory\": url, \"OutputFilenamePrefix\": \"adc-dataflow\"}"
       - name: labels
         description: User labels to be specified for the job.
         varType: map(string)

--- a/modules/flex/metadata.yaml
+++ b/modules/flex/metadata.yaml
@@ -78,7 +78,7 @@ spec:
         connections:
           - source:
               source: github.com/terraform-google-modules/terraform-google-service-accounts//modules/simple-sa
-              version: ~> 4.3
+              version: ">= 4.3"
             spec:
               outputExpr: email
       - name: subnetwork


### PR DESCRIPTION
This PR updates the metadata for flex module. The changes are specific to ADC and doesn't impact blueprint users. The PR makes below changes,

* Adds connection with pubsub module
* Adds connection with GCS simple-bucket module
* Adds connection with Bigquery
* Adds limited list of dataflow templates specifically created for ADC.