### PR TITLE
Add support for additional_pipeline_options

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -20,7 +20,6 @@ metadata:
     config.kubernetes.io/local-config: "true"
 spec:
   info:
-    title: Google Dataflow Terraform Modules
     source:
       repo: https://github.com/terraform-google-modules/terraform-google-dataflow.git
       sourceType: git
@@ -43,8 +42,15 @@ spec:
     roles:
       - level: Project
         roles:
-          - roles/owner
           - roles/dataflow.admin
+          - roles/dataflow.worker
+          - roles/storage.admin
+          - roles/compute.networkAdmin
+          - roles/pubsub.editor
+          - roles/bigquery.dataEditor
+          - roles/artifactregistry.writer
+          - roles/iam.serviceAccountUser
+          - roles/resourcemanager.projectIamAdmin
     services:
       - cloudresourcemanager.googleapis.com
       - storage-api.googleapis.com

--- a/modules/dataflow_bucket/metadata.yaml
+++ b/modules/dataflow_bucket/metadata.yaml
@@ -80,5 +80,5 @@ spec:
       - serviceusage.googleapis.com
       - dataflow.googleapis.com
     providerVersions:
-      - source: hashicorp/google-beta
+      - source: hashicorp/google
         version: ">= 3.53, < 7"

--- a/modules/flex/README.md
+++ b/modules/flex/README.md
@@ -56,6 +56,7 @@ Then perform the following commands on the root folder:
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | additional\_experiments | List of experiments that should be used by the job. An example value is `['enable_stackdriver_agent_metrics']` | `list(string)` | `[]` | no |
+| additional\_pipeline\_options | List of pipeline options that should be used by the job. An example value is `['numberOfWorkerHarnessThreads=300','sdkLocation=container']` | `list(string)` | `[]` | no |
 | autoscaling\_algorithm | The algorithm to use for autoscaling. | `string` | `null` | no |
 | container\_spec\_gcs\_path | The GCS path to the Dataflow job Flex Template. | `string` | n/a | yes |
 | enable\_streaming\_engine | Enable/disable the use of Streaming Engine for the job. | `bool` | `false` | no |

--- a/modules/flex/main.tf
+++ b/modules/flex/main.tf
@@ -38,4 +38,5 @@ resource "google_dataflow_flex_template_job" "dataflow_job" {
   additional_experiments       = var.additional_experiments
   parameters                   = var.parameters
   labels                       = var.labels
+  additional_pipeline_options  = var.additional_pipeline_options
 }

--- a/modules/flex/metadata.yaml
+++ b/modules/flex/metadata.yaml
@@ -20,7 +20,6 @@ metadata:
     config.kubernetes.io/local-config: "true"
 spec:
   info:
-    title: Google Dataflow Flex Template Job Terraform Module
     source:
       repo: https://github.com/terraform-google-modules/terraform-google-dataflow.git
       sourceType: git
@@ -140,6 +139,10 @@ spec:
         description: User labels to be specified for the job.
         varType: map(string)
         defaultValue: {}
+      - name: additional_pipeline_options
+        description: List of pipeline options that should be used by the job. An example value is `['numberOfWorkerHarnessThreads=300','sdkLocation=container']`
+        varType: list(string)
+        defaultValue: []
     outputs:
       - name: container_spec_gcs_path
         description: The GCS path to the Dataflow job Flex Template.

--- a/modules/flex/variables.tf
+++ b/modules/flex/variables.tf
@@ -135,3 +135,9 @@ variable "labels" {
   description = "User labels to be specified for the job."
   default     = {}
 }
+
+variable "additional_pipeline_options" {
+  type        = list(string)
+  description = "List of pipeline options that should be used by the job. An example value is `['numberOfWorkerHarnessThreads=300','sdkLocation=container']`"
+  default     = []
+}

--- a/modules/legacy/metadata.yaml
+++ b/modules/legacy/metadata.yaml
@@ -20,7 +20,6 @@ metadata:
     config.kubernetes.io/local-config: "true"
 spec:
   info:
-    title: Google Dataflow Terraform Module
     source:
       repo: https://github.com/terraform-google-modules/terraform-google-dataflow.git
       sourceType: git


### PR DESCRIPTION
Added support for additional_pipeline_options which is recently added to Dataflow API - https://cloud.google.com/dataflow/docs/reference/rest/v1b3/projects.locations.flexTemplates/launch#:~:text=additionalPipelineOptions%5B%5D,flags%20for%20the%20job.

