### PR TITLE
chore: Update the examples to use the new major version

### DIFF
--- a/examples/dlp_api_example/main.tf
+++ b/examples/dlp_api_example/main.tf
@@ -28,7 +28,7 @@ locals {
 
 module "dataflow-bucket" {
   source  = "terraform-google-modules/dataflow/google//modules/dataflow_bucket"
-  version = "~> 2.0"
+  version = "~> 3.0"
 
   name       = local.gcs_bucket_name
   region     = var.region
@@ -110,7 +110,7 @@ EOF
 
 module "dataflow-job" {
   source  = "terraform-google-modules/dataflow/google//modules/legacy"
-  version = "~> 2.0"
+  version = "~> 3.0"
 
   project_id            = var.project_id
   name                  = "dlp_example_${null_resource.download_sample_cc_into_gcs.id}_${null_resource.deinspection_template_setup.id}"

--- a/examples/simple_example/README.md
+++ b/examples/simple_example/README.md
@@ -11,13 +11,13 @@ As featured in this example, using a single regional bucket for storing your job
 Also, to optimize your jobs performance, this bucket should always in the corresponding region of the zones in which your jobs are running.
 
 ## Running the example
-Make sure you grant the addtional permissions below to the service account execute the module:
+Make sure you grant the additional permissions below to the service account execute the module:
 
 - roles/compute.networkAdmin
 
 
 ### Controller Service Account
-This example features the use of a controller service accoun which is specified with the `service_account_email` input variables.
+This example features the use of a controller service account which is specified with the `service_account_email` input variables.
 We recommend using a custome service account with fine-grained access control to mitigate security risks. See more about controller service accounts [here](https://cloud.google.com/dataflow/docs/concepts/security-and-permissions#controller_service_account)
 
 

--- a/examples/simple_example/main.tf
+++ b/examples/simple_example/main.tf
@@ -52,7 +52,7 @@ module "vpc" {
 
 module "dataflow-bucket" {
   source  = "terraform-google-modules/dataflow/google//modules/dataflow_bucket"
-  version = "~> 2.0"
+  version = "~> 3.0"
 
   name          = local.gcs_bucket_name
   region        = var.region
@@ -62,7 +62,7 @@ module "dataflow-bucket" {
 
 module "dataflow-job" {
   source  = "terraform-google-modules/dataflow/google//modules/legacy"
-  version = "~> 2.0"
+  version = "~> 3.0"
 
   project_id            = var.project_id
   name                  = "wordcount-terraform-example"
@@ -84,7 +84,7 @@ module "dataflow-job" {
 
 module "dataflow-job-2" {
   source  = "terraform-google-modules/dataflow/google//modules/legacy"
-  version = "~> 2.0"
+  version = "~> 3.0"
 
   project_id            = var.project_id
   name                  = "wordcount-terraform-example-2"


### PR DESCRIPTION
This PR fixes an error introduced in the last major version release. It addresses issues where specific fields were renamed or removed, but the module was still referencing the previous version's schema. This update synchronizes the module with the current major version.

> **NOTE:** This is labeled as a **chore** because it only updates the example documentation to align with the latest major version. It does not change the underlying module code.